### PR TITLE
Fix decodeRC dict keys

### DIFF
--- a/buildbot_pipeline/steps.py
+++ b/buildbot_pipeline/steps.py
@@ -46,6 +46,11 @@ def gen_steps(step, data):
         data['shell'] = data.pop('shell-fail')
         data['haltOnFailure'] = True
 
+    if 'decodeRC' in data:
+        # keys are implicitly converted to str during json dumping
+        # fix type back to int
+        data['decodeRC'] = {int(i): k for i, k in data['decodeRC'].items()}
+
     if 'shell' in data:
         data['command'] = data.pop('shell')
         step_env = data.get('env', {})


### PR DESCRIPTION
decodeRC dict keys are implicitly converted to str during json dumping.
fix it before using in step